### PR TITLE
Improve documentation for Graph Tutorial

### DIFF
--- a/documentation/GraphTutorial.md
+++ b/documentation/GraphTutorial.md
@@ -138,7 +138,7 @@ And finally we define the build method:
 ```st
 GraphAnalyzer>>build
     layout on: elements.
-    ^ canvas addAll: elements; yourself
+    ^ canvas
 ```
 
 We can now try our first script:

--- a/documentation/GraphTutorial.md
+++ b/documentation/GraphTutorial.md
@@ -65,8 +65,8 @@ eb connectToAll: relation.
 RSGridLayout on: elements.
 
 c edges do: #withBorder.
-c edges @ RSHighlightable defaultRed.
-c nodes @ RSHighlightable defaultRed withOutgoingEdges.
+c edges @ RSHighlightable red.
+c nodes @ RSHighlightable red withOutgoingEdges.
 
 RSForceBasedLayout new charge: -200; on: elements.
 
@@ -82,8 +82,8 @@ Finally, nodes are connected using the expression `eb connectToAll: relation`. S
 We add a bit of interaction to make visual element highlightable. The three lines:
 ```Smalltalk
 c edges do: #withBorder.
-c edges @ RSHighlightable defaultRed.
-c nodes @ RSHighlightable defaultRed withOutgoingEdges.
+c edges @ RSHighlightable red.
+c nodes @ RSHighlightable red withOutgoingEdges.
 ```
 make the visual elements aware of the mouse movement. If the mouse is above a node, it is highlighted as well as outgoing edges.
 
@@ -177,8 +177,8 @@ GraphAnalyzer>>relation: aOneArgBlock
 	eb connectToAll: aOneArgBlock.
 
 	canvas edges do: #withBorder.
-	canvas edges @ RSHighlightable defaultRed.
-	canvas nodes @ RSHighlightable defaultRed withOutgoingEdges.
+	canvas edges @ RSHighlightable red.
+	canvas nodes @ RSHighlightable red withOutgoingEdges.
 ```
 
 The following code produce the same result than our original script:


### PR DESCRIPTION
PR fixes following issues encountered while going through the [Graph Tutorial](https://github.com/ObjectProfile/Roassal3Documentation/blob/master/documentation/GraphTutorial.md):

Deprecated `defaultRed` message
![Screenshot from 2022-09-27 13-54-17](https://user-images.githubusercontent.com/14095576/192623740-c003bac0-fbf5-4dfb-a1bd-61bc1a7efbee.png)

Edges not rendering
![Screenshot from 2022-09-27 13-54-42](https://user-images.githubusercontent.com/14095576/192623847-7c18933f-4771-45a8-becc-fe6f5b823006.png)

Fixed as of 4a0b6d833cb06bffba9cf4d2dbdc0c0a823166ab
![Screenshot from 2022-09-27 13-48-26](https://user-images.githubusercontent.com/14095576/192624049-70902ce4-56d7-4352-a784-df9fd3d15f41.png)
